### PR TITLE
Move CNAME record to API hosted zone

### DIFF
--- a/infrastructure/dns-records-shared-signals/template.yaml
+++ b/infrastructure/dns-records-shared-signals/template.yaml
@@ -128,7 +128,7 @@ Resources:
   SharedSignalsTransmitterCognitoCnameRecord:
     Type: AWS::Route53::RecordSet
     Properties:
-      HostedZoneId: !ImportValue SharedSignalsTransmitterApiPublicHostedZone
+      HostedZoneId: !ImportValue SharedSignalsTransmitterApiPublicHostedZoneId
       Name: !If
         - IsProduction
         - auth.shared-signals-transmitter.transaction.account.gov.uk


### PR DESCRIPTION
The CNAME record needs to be in the parent hosted zone, not the Cognito hosted zone.