### PR TITLE
SET-1134 | Create a Route53 A record for the API Gateway

### DIFF
--- a/infrastructure/dns-olse-outbound/template.yaml
+++ b/infrastructure/dns-olse-outbound/template.yaml
@@ -89,6 +89,19 @@ Resources:
       Name: MockReceiverApiDomainName
       Type: String
       Value: !Ref SharedSignalsMockReceiverApiDomainName
+
+  SharedSignalsMockReceiverApiAliasRecord:
+    Condition: MockReceiverCustomDomain
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt SharedSignalsMockReceiverApiDomainName.RegionalDomainName
+        EvaluateTargetHealth: false
+        HostedZoneId: !GetAtt SharedSignalsMockReceiverApiDomainName.RegionalHostedZoneId
+      HostedZoneId: !GetAtt SharedSignalsMockReceiverApiPublicHostedZone.Id
+      Name: !Ref SharedSignalsMockReceiverApiDomainName
+      Type: A
+
   ###############
   #  Transmitter  #
   ###############
@@ -156,6 +169,18 @@ Resources:
       Name: TransmitterApiDomainName
       Type: String
       Value: !Ref SharedSignalsTransmitterApiDomainName
+
+  SharedSignalsTransmitterApiAliasRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt SharedSignalsTransmitterApiDomainName.RegionalDomainName
+        EvaluateTargetHealth: false
+        HostedZoneId: !GetAtt SharedSignalsTransmitterApiDomainName.RegionalHostedZoneId
+      HostedZoneId: !GetAtt SharedSignalsTransmitterApiPublicHostedZone.Id
+      Name: !Ref SharedSignalsTransmitterApiDomainName
+      Type: A
+
   ###############################
 
   # Transmitter Cognito User Pool  #


### PR DESCRIPTION
- [SET-1134 ](https://govukverify.atlassian.net/browse/SET-1134)
- **Documentation Link(s)**: [:books: Does this relate to an ADR/RFC/Spike ticket?]

## :bulb: Description

Added alias A records for Mock Receiver and Transmitter custom domains.

## :sparkles: Changes Made

Added `SharedSignalsMockReceiverApiAliasRecord` and `SharedSignalsTransmitterApiAliasRecord` Route 53 alias A records to route traffic from the custom domain names to their respective API Gateway regional endpoints.

## :test_tube: Testing Instructions/Notes

[Provide step-by-step instructions for testing the changes made in this pull request. Were there any tests you weren't able to include but would have liked to? ]

## :frame_with_picture: Screenshots (if applicable)

[Include any screenshots or visual representations of the changes. Delete this section if not applicable.]

## :handshake: Related Pull Requests

- [List any related pull requests that need to be reviewed or merged alongside this one.]

## :white_tick: Documentation update

- [Please provide proper documentation or update existing documentation both in the README and within our confluence pages. If there is any documentation you have yet to update please detail it here. ]

## :memo: Additional Notes

[Add any additional information, context, or notes that reviewers or contributors should be aware of.]

<!-- You can remove any sections that are not applicable to your pull request. -->
