### PR TITLE
SET-1398 | DNS Delegation for sub domains hosted zones

### DIFF
--- a/infrastructure/dns-olse-inbound/template.yaml
+++ b/infrastructure/dns-olse-inbound/template.yaml
@@ -33,6 +33,18 @@ Resources:
         - receiver.signal-exchange.account.gov.uk
         - !Sub 'receiver.signal-exchange.${Environment}.account.gov.uk'
 
+  FraudSSFReceiverDnsDelegation:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !ImportValue SignalExchangeHostedZoneId
+      Name: !If
+        - IsProduction
+        - receiver.signal-exchange.account.gov.uk
+        - !Sub 'receiver.signal-exchange.${Environment}.account.gov.uk'
+      ResourceRecords: !GetAtt FraudSSFReceiverApiPublicHostedZone.NameServers
+      TTL: '300'
+      Type: NS
+
   ###########
   # Cognito #
   ###########
@@ -46,3 +58,15 @@ Resources:
         - IsProduction
         - auth.receiver.signal-exchange.account.gov.uk
         - !Sub 'auth.receiver.signal-exchange.${Environment}.account.gov.uk'
+
+  SignalExchangeTransmitterCognitoDnsDelegation:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !ImportValue SignalExchangeHostedZoneId
+      Name: !If
+        - IsProduction
+        - auth.receiver.signal-exchange.account.gov.uk
+        - !Sub 'auth.receiver.signal-exchange.${Environment}.account.gov.uk'
+      ResourceRecords: !GetAtt FraudSSFReceiverCognitoPublicHostedZone.NameServers
+      TTL: '300'
+      Type: NS


### PR DESCRIPTION
- **[SET-1398](https://govukverify.atlassian.net/browse/SET-1398)**
- **Documentation Link(s)**: [:books: Does this relate to an ADR/RFC/Spike ticket?]

## :bulb: Description

Adds NS records to delegate DNS from the parent `SignalExchangeHostedZone` to the receiver and Cognito subdomain hosted zones. This uses !ImportValue `SignalExchangeHostedZoneId` from the outbound stack.

## :sparkles: Changes Made

- [List the specific changes made in bullet points. Be as detailed as necessary.]

## :test_tube: Testing Instructions/Notes

[Provide step-by-step instructions for testing the changes made in this pull request. Were there any tests you weren't able to include but would have liked to? ]

## :frame_with_picture: Screenshots (if applicable)

[Include any screenshots or visual representations of the changes. Delete this section if not applicable.]

## :handshake: Related Pull Requests

- [List any related pull requests that need to be reviewed or merged alongside this one.]

## :white_tick: Documentation update

- [Please provide proper documentation or update existing documentation both in the README and within our confluence pages. If there is any documentation you have yet to update please detail it here. ]

## :memo: Additional Notes

[Add any additional information, context, or notes that reviewers or contributors should be aware of.]

<!-- You can remove any sections that are not applicable to your pull request. -->


[SET-1398]: https://govukverify.atlassian.net/browse/SET-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ