### PR TITLE
SET-1398 | Adding mapping for Signal Exchange Parent zone and DNS delegation resources 

### DIFF
--- a/infrastructure/dns-olse-inbound/template.yaml
+++ b/infrastructure/dns-olse-inbound/template.yaml
@@ -13,7 +13,7 @@ Parameters:
       - production
 
 Mappings:
-  ParentHostedZoneIds:
+  ParentHostedZoneIds: # Hardcoded values as SignalExchangeHostedZones lives in the Shared Signals AWS Account in this template here https://github.com/govuk-one-login/txma-dns/blob/main/infrastructure/dns-olse-outbound/template.yaml#L25 and !ImportValue cannot be used cross-account hence why we have decided to add values in the mappings to be referenced via !FindInMap.
     build:
       SignalExchangeHostedZoneId: Z0642694YO506V4QP5
     staging:

--- a/infrastructure/dns-olse-inbound/template.yaml
+++ b/infrastructure/dns-olse-inbound/template.yaml
@@ -13,7 +13,7 @@ Parameters:
       - production
 
 Mappings:
-  HostedZoneIds:
+  ParentHostedZoneIds:
     build:
       SignalExchangeHostedZoneId: Z0642694YO506V4QP5
     staging:
@@ -47,7 +47,7 @@ Resources:
   FraudSSFReceiverDnsDelegation:
     Type: AWS::Route53::RecordSet
     Properties:
-      HostedZoneId: !FindInMap [HostedZoneIds, !Ref Environment, SignalExchangeHostedZoneId]
+      HostedZoneId: !FindInMap [ParentHostedZoneIds, !Ref Environment, SignalExchangeHostedZoneId]
       Name: !If
         - IsProduction
         - receiver.signal-exchange.account.gov.uk
@@ -73,7 +73,7 @@ Resources:
   SignalExchangeTransmitterCognitoDnsDelegation:
     Type: AWS::Route53::RecordSet
     Properties:
-      HostedZoneId: !FindInMap [HostedZoneIds, !Ref Environment, SignalExchangeHostedZoneId]
+      HostedZoneId: !FindInMap [ParentHostedZoneIds, !Ref Environment, SignalExchangeHostedZoneId]
       Name: !If
         - IsProduction
         - auth.receiver.signal-exchange.account.gov.uk

--- a/infrastructure/dns-olse-inbound/template.yaml
+++ b/infrastructure/dns-olse-inbound/template.yaml
@@ -12,6 +12,17 @@ Parameters:
       - integration
       - production
 
+Mappings:
+  HostedZoneIds:
+    build:
+      SignalExchangeHostedZoneId: Z0642694YO506V4QP5
+    staging:
+      SignalExchangeHostedZoneId: Z064216513RP67UPZIN3O
+    integration:
+      SignalExchangeHostedZoneId: Z06469731BEEOQ2HDBB1E
+    production:
+      SignalExchangeHostedZoneId: Z08278793VE452BET1X9M
+
 Conditions:
   IsProduction: !Equals
     - !Ref Environment
@@ -33,6 +44,18 @@ Resources:
         - receiver.signal-exchange.account.gov.uk
         - !Sub 'receiver.signal-exchange.${Environment}.account.gov.uk'
 
+  FraudSSFReceiverDnsDelegation:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !FindInMap [HostedZoneIds, !Ref Environment, SignalExchangeHostedZoneId]
+      Name: !If
+        - IsProduction
+        - receiver.signal-exchange.account.gov.uk
+        - !Sub 'receiver.signal-exchange.${Environment}.account.gov.uk'
+      ResourceRecords: !GetAtt FraudSSFReceiverApiPublicHostedZone.NameServers
+      TTL: '300'
+      Type: NS
+
   ###########
   # Cognito #
   ###########
@@ -46,3 +69,15 @@ Resources:
         - IsProduction
         - auth.receiver.signal-exchange.account.gov.uk
         - !Sub 'auth.receiver.signal-exchange.${Environment}.account.gov.uk'
+
+  SignalExchangeTransmitterCognitoDnsDelegation:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !FindInMap [HostedZoneIds, !Ref Environment, SignalExchangeHostedZoneId]
+      Name: !If
+        - IsProduction
+        - auth.receiver.signal-exchange.account.gov.uk
+        - !Sub 'auth.receiver.signal-exchange.${Environment}.account.gov.uk'
+      ResourceRecords: !GetAtt FraudSSFReceiverCognitoPublicHostedZone.NameServers
+      TTL: '300'
+      Type: NS


### PR DESCRIPTION
- **[SET-1398](https://govukverify.atlassian.net/browse/SET-1398)**
- **Documentation Link(s)**: [:books: Does this relate to an ADR/RFC/Spike ticket?]

## :bulb: Description

Add DNS delegation for receiver and Cognito subdomain hosted zones

The parent `SignalExchangeHostedZone` lives in a different AWS account (Shared Signals), so `!ImportValue` cannot be used cross-account. Instead, a Mappings block is used with `!FindInMap` to look up the hosted zone ID per environment.

## :sparkles: Changes Made

Mappings added for `ParentHostedZoneIds` 
Dns Delegation resources 
## :test_tube: Testing Instructions/Notes

[Provide step-by-step instructions for testing the changes made in this pull request. Were there any tests you weren't able to include but would have liked to? ]

## :frame_with_picture: Screenshots (if applicable)

[Include any screenshots or visual representations of the changes. Delete this section if not applicable.]

## :handshake: Related Pull Requests

- [List any related pull requests that need to be reviewed or merged alongside this one.]

## :white_tick: Documentation update

- [Please provide proper documentation or update existing documentation both in the README and within our confluence pages. If there is any documentation you have yet to update please detail it here. ]

## :memo: Additional Notes

[Add any additional information, context, or notes that reviewers or contributors should be aware of.]

<!-- You can remove any sections that are not applicable to your pull request. -->


[SET-1398]: https://govukverify.atlassian.net/browse/SET-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ