### PR TITLE
SET-1293 | Route53 A Record for new Receiver

### DIFF
--- a/infrastructure/dns-olse-inbound/template.yaml
+++ b/infrastructure/dns-olse-inbound/template.yaml
@@ -80,6 +80,17 @@ Resources:
       Type: String
       Value: !Ref FraudSSFReceiverApiDomainName
 
+  FraudSSFReceiverApiAliasRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      AliasTarget:
+        DNSName: !GetAtt FraudSSFReceiverApiDomainName.RegionalDomainName
+        EvaluateTargetHealth: false
+        HostedZoneId: !GetAtt FraudSSFReceiverApiDomainName.RegionalHostedZoneId
+      HostedZoneId: !GetAtt FraudSSFReceiverApiPublicHostedZone.Id
+      Name: !Ref FraudSSFReceiverApiDomainName
+      Type: A
+
   ###########
   # Cognito #
   ###########


### PR DESCRIPTION
- **[SET-1293](https://govukverify.atlassian.net/browse/SET-1293) **
- **Documentation Link(s)**: [:books: Does this relate to an ADR/RFC/Spike ticket?]

## :bulb: Description

Adding `FraudSSFReceiverApiAliasRecord` creates a DNS A record (alias) in the public hosted zone that points the custom domain name to the actual regional API Gateway Endpoint after creating the domain name for it with the resource `AWS::ApiGateway::DomainName ` as without it the custom domain name `FraudSSFReceiverApiDomainName` would exist but DNS wouldn't know how to resolve it. 


## :sparkles: Changes Made

`FraudSSFReceiverApiAliasRecord` resource created 

## :test_tube: Testing Instructions/Notes

[Provide step-by-step instructions for testing the changes made in this pull request. Were there any tests you weren't able to include but would have liked to? ]

## :frame_with_picture: Screenshots (if applicable)

[Include any screenshots or visual representations of the changes. Delete this section if not applicable.]

## :handshake: Related Pull Requests

- [List any related pull requests that need to be reviewed or merged alongside this one.]

## :white_tick: Documentation update

- [Please provide proper documentation or update existing documentation both in the README and within our confluence pages. If there is any documentation you have yet to update please detail it here. ]

## :memo: Additional Notes

[Add any additional information, context, or notes that reviewers or contributors should be aware of.]

<!-- You can remove any sections that are not applicable to your pull request. -->


[SET-1293]: https://govukverify.atlassian.net/browse/SET-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ